### PR TITLE
Add spotify

### DIFF
--- a/pkglist
+++ b/pkglist
@@ -3,4 +3,4 @@ ectool-samus-git
 pikaur
 mxt-app-git
 signal-desktop-bin
-rocketchat-desktop
+spotify


### PR DESCRIPTION
This adds spotify player.
It also removes RocketChat, which doesn't allow to setup a socks
proxy.